### PR TITLE
Allow forwarding of an order update containing 0 nodes and 0 edges

### DIFF
--- a/src/models/Order.cpp
+++ b/src/models/Order.cpp
@@ -7,8 +7,11 @@ void Order::Validate() {
   // TODO: Add validation based on AGV's capabilities (e.g. track planning etc.). Using FactSheet
   // messages
 
-  if (this->order.edges.size() != this->order.nodes.size() - 1) {
-    throw std::runtime_error("Number of edges not equal to number of nodes - 1!");
+  if (this->order.nodes.size() != 0)
+  {
+    if (this->order.edges.size() != this->order.nodes.size() - 1) {
+      throw std::runtime_error("Number of edges not equal to number of nodes - 1!");
+    }
   }
 
   // Loop over the edges, and validate that the order has a good sequence.

--- a/src/vda5050_connector/vda5050_connector.cpp
+++ b/src/vda5050_connector/vda5050_connector.cpp
@@ -193,18 +193,25 @@ void VDA5050Connector::OrderCallback(const vda5050_msgs::Order::ConstPtr& msg) {
       return;
     } else {
       // Compare the information of the last order with the newly received order update.
-      try {
-        state.ValidateUpdateBase(new_order);
-      } catch (const std::runtime_error& e) {
-        ROS_ERROR("Update base validation failed. %s", e.what());
-
-        // Add error to the state message.
-
-        return;
+      if (new_order.GetNodes().size() == 0 && new_order.GetEdges().size() == 0)
+      {
+        ROS_WARN("Order update has no nodes and no edges");
       }
+      else
+      {
+        try {
+          state.ValidateUpdateBase(new_order);
+        } catch (const std::runtime_error& e) {
+          ROS_ERROR("Update base validation failed. %s", e.what());
 
-      // Accept the order update by updating the state and the order message.
-      UpdateExistingOrder(new_order);
+          // Add error to the state message.
+
+          return;
+        }
+
+        // Accept the order update by updating the state and the order message.
+        UpdateExistingOrder(new_order);
+      }
 
       ROS_INFO("Sending order update");
 


### PR DESCRIPTION
Changes allowing to forward an order update containing 0 nodes and 0 edges. Can be used to remove the horizon of an order, ending this order without canceling it. 